### PR TITLE
Update Navbar.tsx

### DIFF
--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -1,11 +1,40 @@
 'use client';
 
 import Link from 'next/link';
-import { AppBar, Toolbar, Typography, IconButton, Box } from '@mui/material';
-import { Brain } from 'lucide-react';
+import { AppBar, Toolbar, Typography, IconButton, Box, useMediaQuery, Drawer, List, ListItem, ListItemText } from '@mui/material';
+import { Brain, Menu } from 'lucide-react';
+import { useState } from 'react';
 import NavbarButtons from './Utils/NavbarButtons';
 
 const Navbar = () => {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const isMobile = useMediaQuery('(max-width:600px)');
+
+  const toggleDrawer = (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
+    if (event.type === 'keydown' && ((event as React.KeyboardEvent).key === 'Tab' || (event as React.KeyboardEvent).key === 'Shift')) {
+      return;
+    }
+    setDrawerOpen(open);
+  };
+
+  const drawer = (
+    <Box
+      sx={{ width: 250 }}
+      role="presentation"
+      onClick={toggleDrawer(false)}
+      onKeyDown={toggleDrawer(false)}
+    >
+      <List>
+        <ListItem button component={Link} href="/">
+          <ListItemText primary="Home" />
+        </ListItem>
+        <ListItem button component={Link} href="https://github.com/AOSSIE-Org/Perspective-AI">
+          <ListItemText primary="GitHub" />
+        </ListItem>
+      </List>
+    </Box>
+  );
+
   return (
     <AppBar
       position="static"
@@ -27,10 +56,30 @@ const Navbar = () => {
             Perspective AI
           </Typography>
         </Box>
-        <Box display="flex" gap={2}>
-          <NavbarButtons text="Home" href="/" />
-          <NavbarButtons text="GitHub" href="https://github.com/AOSSIE-Org/Perspective-AI" />
-        </Box>
+        {isMobile ? (
+          <>
+            <IconButton
+              edge="end"
+              color="inherit"
+              aria-label="menu"
+              onClick={toggleDrawer(true)}
+            >
+              <Menu />
+            </IconButton>
+            <Drawer
+              anchor="right"
+              open={drawerOpen}
+              onClose={toggleDrawer(false)}
+            >
+              {drawer}
+            </Drawer>
+          </>
+        ) : (
+          <Box display="flex" gap={2}>
+            <NavbarButtons text="Home" href="/" />
+            <NavbarButtons text="GitHub" href="https://github.com/AOSSIE-Org/Perspective-AI" />
+          </Box>
+        )}
       </Toolbar>
     </AppBar>
   );


### PR DESCRIPTION
 I've added a responsive drawer for mobile devices using Material-UI's Drawer component. The useMediaQuery hook is used to determine if the screen width is less than 600px, and if so, a menu icon is displayed instead of the navigation buttons. When the menu icon is clicked, a drawer slides out from the right, containing the navigation links.