### PR TITLE
fixed wrong call to get_perspective_arguments

### DIFF
--- a/backend/app/services/counter_service.py
+++ b/backend/app/services/counter_service.py
@@ -16,8 +16,9 @@ def generate_opposite_perspective(article_text):
     }
     
    
-    final_prompt = get_opposite_perspective_prompt(article_text)
-    
+    # final_prompt = get_opposite_perspective_prompt(article_text)
+    final_prompt = get_opposite_perspective_prompt().format(article_text=article_text)
+
     
     payload = {
         "model": "deepseek/deepseek-chat",


### PR DESCRIPTION
Fixed the Internal server error when generating AI summary

the "get_opposite_perspective_prompt()" doesn't take any arguments , but is called with "article_text" in "backend/app/services/counter_service.py"

NOTE : the function  can also be modified to take arguments in the definition like this  "get_opposite_perspective_prompt(article text)"  in "backend/app/prompts/opposite_perspective.py"