### PR TITLE
Update README: Replace HF Token with OpenRouter API Key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,17 @@ npm run dev
 
 ### Backend Setup
 
-*Get HuggingFace Access Token:*
-- Go to HuggingFace website and create new access token.
-- copy that token
+*Get OpenRouter API Key:*
+- Go to [OpenRouter](https://openrouter.ai/) and log in to your account.
+- Navigate to the API Keys section and generate a new API key.
+- Copy the key for further setup.
+
 
 *Setup environment variables:*
   - add .env file in `/backend`directory.
   - add following environment variable in your .env file.
   ```
-  HF_TOKEN = <Your_hugging_face_access_token>
+  API_KEY = <Your_OpenRouter_API_Key>
   ```
 
 


### PR DESCRIPTION
This PR updates the README.md file to improve the setup instructions.

_Errors encountered due to the previous instructions._

![image](https://github.com/user-attachments/assets/5dd6f52f-6adc-43d3-b76c-138b43f2ab33)


**Changes Made:**

-> Removed the step for adding the Hugging Face (HF) Token, as it is no longer required.
-> Added clear instructions for setting up the OpenRouter API Key instead.

`API_KEY=<Your_OpenRouter_API_Key>`


**Reason for Change:**

 -> Previously, the README mentioned adding an HF Token, which is now obsolete. Since we are using the OpenRouter API Key for authentication, updating the setup steps ensures that developers can run the project locally without confusion or errors.


@ParagGhatage @ishaanxgupta Hey, please take a look at this as we already discussed it this morning, let me know if this is good to go?


 
 