### PR TITLE
fix: add sqlalchemy in requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 newspaper3k
 httpx
 python-dotenv
+sqlalchemy


### PR DESCRIPTION
sqlalchemy was missing from requirements.txt

It was a minor addition, so I skipped creating an issue or discussing it on Discord and directly submitted a PR