### PR TITLE
added .npmrc to allow legacy peer deps for deployment on vercel

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Due to version conflict of library `react-day-picker`, 
- Added .npmrc file to allow deployment of frontend on vercel.