### PR TITLE
feat: add GitHub issue templates (bug, feature, docs) Closes #70

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: "🐞 Bug report"
+description: "File a bug to help us improve"
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: "Steps to reproduce"
+      placeholder: "1. Go to …\n2. Click on …\n3. Observe …"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected behaviour"
+      placeholder: "Describe what you expected to happen."
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual behaviour"
+      placeholder: "Describe what actually happened."
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: "Environment (OS, browser, version, etc.)"
+      placeholder: "e.g., Windows 11, Chrome 110, Node.js 20"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "❓ Questions / Discussions"
+    url: "https://github.com/AOSSIE-Org/Perspective/discussions"
+    about: "Use GitHub Discussions for general questions or support."

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,19 @@
+name: "📖 Documentation update"
+description: "Report missing, outdated, or incorrect documentation"
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: "Affected page / section"
+      placeholder: "e.g., README.md, API guide, paragraph 3"
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: "Suggested change"
+      placeholder: "Explain what needs to be updated, added, or removed."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: "✨ Feature request"
+description: "Suggest an idea or improvement for this project"
+title: "[Feat]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problem / Motivation"
+      placeholder: "Describe the problem this feature solves or improves."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Proposed solution"
+      placeholder: "Describe the solution or approach you suggest."
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: "Additional context / mock-ups / screenshots"
+      placeholder: "Provide any extra context, links, or visual examples if applicable."


### PR DESCRIPTION
This PR adds structured GitHub issue templates to the repository to improve clarity for contributors. 

Includes:
- Bug Report template
- Feature Request template
- Documentation Update template
- Config file for blank/general issues

These templates will standardize issue submissions and make the repository feel more organized and contributor-friendly.

Closes #70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized GitHub issue templates to improve issue submissions and information collection
  * Bug report template requires reproduction steps, expected/actual behavior, and environment details
  * Feature request template captures problem, proposed solution, and additional context
  * Documentation update template allows users to suggest documentation improvements
  * Configured issue template settings with link to discussions for general questions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->