### PR TITLE
fix(backend): replace decommissioned gemma2-9b-it with llama-3.3-70b-versatile

### DIFF
--- a/backend/app/modules/bias_detection/check_bias.py
+++ b/backend/app/modules/bias_detection/check_bias.py
@@ -61,7 +61,7 @@ def check_bias(text):
                     "content": (f"Give bias score to the following article \n\n{text}"),
                 },
             ],
-            model="gemma2-9b-it",
+            model="llama-3.3-70b-versatile",
             temperature=0.3,
             max_tokens=512,
         )

--- a/backend/app/modules/chat/llm_processing.py
+++ b/backend/app/modules/chat/llm_processing.py
@@ -55,7 +55,7 @@ Question:
 """
 
     response = client.chat.completions.create(
-        model="gemma2-9b-it",
+        model="llama-3.3-70b-versatile",
         messages=[
             {"role": "system", "content": "Use only the context to answer."},
             {"role": "user", "content": prompt},

--- a/backend/app/modules/facts_check/llm_processing.py
+++ b/backend/app/modules/facts_check/llm_processing.py
@@ -144,7 +144,13 @@ def run_fact_verifier_sdk(search_results):
                 parsed = json.loads(content)
             except Exception as parse_err:
                 logger.error(f"LLM JSON parse error: {parse_err}")
-
+             parsed = {
+                    "verdict": "Unknown",
+                    "explanation": f"Parse error: {parse_err}",
+                    "original_claim": claim,
+                    "source_link": source,
+                }
+            
             results_list.append(parsed)
 
         return {

--- a/backend/app/modules/facts_check/llm_processing.py
+++ b/backend/app/modules/facts_check/llm_processing.py
@@ -63,7 +63,7 @@ def run_claim_extractor_sdk(state):
                     ),
                 },
             ],
-            model="gemma2-9b-it",
+            model="llama-3.3-70b-versatile",
             temperature=0.3,
             max_tokens=512,
         )
@@ -128,7 +128,7 @@ def run_fact_verifier_sdk(search_results):
                         ),
                     },
                 ],
-                model="gemma2-9b-it",
+                model="llama-3.3-70b-versatile",
                 temperature=0.3,
                 max_tokens=256,
             )

--- a/backend/app/modules/langgraph_nodes/judge.py
+++ b/backend/app/modules/langgraph_nodes/judge.py
@@ -24,7 +24,7 @@ logger = setup_logger(__name__)
 
 # Init once
 groq_llm = ChatGroq(
-    model="gemma2-9b-it",
+    model="llama-3.3-70b-versatile",
     temperature=0.0,
     max_tokens=10,
 )

--- a/backend/app/modules/langgraph_nodes/sentiment.py
+++ b/backend/app/modules/langgraph_nodes/sentiment.py
@@ -49,7 +49,7 @@ def run_sentiment_sdk(state):
                     ),
                 },
             ],
-            model="gemma2-9b-it",
+            model="llama-3.3-70b-versatile",
             temperature=0.2,
             max_tokens=3,
         )


### PR DESCRIPTION
Fixes #134
## Description
The current hardcoded model `gemma2-9b-it` has been decommissioned by Groq, causing the backend to crash with `groq.BadRequestError` immediately upon running any analysis (Bias, Chat, or Fact-Check).

## Changes Proposed
* Updated all backend instances of `gemma2-9b-it` to the stable `llama-3.3-70b-versatile` model.
* Verified compatibility with existing prompts.

## Verification
* ✅ **Bias Analysis:** Success (Score generated).
* ✅ **Chat:** Success (Responds to context).

## Reasoning
* **Compatibility:** `llama-3.3-70b` is natively supported by the existing Groq client, requiring zero code refactoring.
* **Capabilities:** As a 70B parameter model, it offers superior reasoning for Bias and Fact-Check analysis compared to the decommissioned 9B model.
* **Stability:** It is the current stable flagship on Groq, ensuring long-term reliability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the underlying AI model used across core processing modules to improve response quality and consistency.
  * No user-facing behavior or workflows were changed; existing prompts, outputs, and error handling remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->